### PR TITLE
Comments moveapps

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ MoveApps
 Github repository: https://github.com/ctmm-initiative/moveapps_ctmm_outlier
 
 ## Description
-This app allows to detect relocation that are likely outlier based on speed and distance traveled. 
+This app removes relocations that are likely outliers based on a user-provided threshold for either speed or distance traveled. Based on the outlie() function of the ctmm package.
 
 ## Documentation
 
@@ -20,9 +20,9 @@ none
 
 ### Settings
 
-`Select variable`: select a variable to be used for filtering.  
+`Select variable`: select a variable to be used for filtering. Options are speed or distance moved. Default is X (? PLEASE ADAPT)
 
-`Range`: select an acceptable range for the selected variable.   
+`Range`: select an acceptable range for the selected variable. Any relocations that are not within the user-set range will be removed from the data set.  
 
 `Store settings`: click to store the current settings of the app for future workflow runs  
 

--- a/ShinyModule.R
+++ b/ShinyModule.R
@@ -1,5 +1,4 @@
 library(shiny)
-library(move)
 library(dplyr)
 library(ggplot2)
 library(tidyr)

--- a/appspec.json
+++ b/appspec.json
@@ -30,7 +30,7 @@
       }
     ]
   },
-  "createsArtifacts": true,
+  "createsArtifacts": false,
   "license": {
     "key": "MIT"
   },

--- a/appspec.json
+++ b/appspec.json
@@ -5,9 +5,6 @@
         "name": "lubridate",
       },
       {
-        "name": "move"
-      },
-      {
         "name": "ctmm"
       },
       {

--- a/appspec.json
+++ b/appspec.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "R": [
       {
-        "name": "lubridate",
+        "name": "shiny",
       },
       {
         "name": "ctmm"


### PR DESCRIPTION
Hi @jmsigner and @marcosci, Andrea and me did some minor modifications (see commits). I found 2 things in the App, but I think it quicker if you adjust the code.
- outlier histogram: x-axis is always "speed", also when distance is selected. If it is easy, it would also be nice to see the units of the x-axis.
- it seems that this app does not output any data. In this case it should be the data excluding the locations selected by the user to be excluded, based on speed or distance, right?

And this goes for all apps: please also add a branch protection rule to your main branch. We use just the first option there that a PR is required for people to suggest changes. (here: Settings> Branches > Add a protection rule)